### PR TITLE
Initialize frontend and API scaffolding with FTP deployment

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: jino
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Upload via FTP
+        uses: SamKirkland/FTP-Deploy-Action@4.3.0
+        with:
+          server: ${{ vars.FTP_HOST }}
+          username: ${{ vars.FTP_USERNAME }}
+          password: ${{ vars.FTP_PASSWORD }}
+          local-dir: frontend
+          server-dir: /

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Lunawar</title>
+</head>
+<body>
+  Hello from Lunawar!
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder frontend with "Hello from Lunawar" index
- add empty API project scaffold
- configure GitHub Actions workflow to deploy frontend via FTP using environment variables from `jino`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c4407448328b31b39a91591e03f