### PR TITLE
feat: manual deploy for frontend

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,11 +1,7 @@
 name: Deploy Frontend
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/**'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- run frontend deploy workflow only when manually triggered

## Testing
- `npm test` (fails: ENOENT package.json)
- `pre-commit run --files .github/workflows/frontend-deploy.yml` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac7e6dbcdc8328ac93953cc65178d5