### PR TITLE
fix: pin ftp deploy action version

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
 
       - name: Upload via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}


### PR DESCRIPTION
## Summary
- pin FTP deploy action to explicit v4.3.5 tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac89c355288328b281bff0e266d646