### PR TITLE
Fix FTP deploy workflow input

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -32,5 +32,5 @@ jobs:
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: frontend
-          remote-dir: /
+          server-dir: /
           protocol: ftps


### PR DESCRIPTION
## Summary
- fix SamKirkland FTP deploy action configuration by replacing deprecated `remote-dir` with `server-dir`

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68accd879a648328a10c51099d68a138