### PR TITLE
Trigger frontend deploy on merge and manual run

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -2,9 +2,15 @@ name: Deploy Frontend
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     environment: jino
     steps:


### PR DESCRIPTION
## Summary
- deploy frontend automatically when a PR to `main` is merged
- keep manual deployment via workflow dispatch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99be42cc8328850ee9d022ba5214