### PR TITLE
feat(shared): add shared types, events, i18n helper and redis keys

### DIFF
--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,1 +1,24 @@
 # Shared Package
+
+Common types, events, i18n helpers and Redis key generators shared across the project.
+
+## Types
+- `User`
+- `RoomMeta`
+- `Message`
+- `LobbySnapshot`
+
+## Events
+- `lobby.joined`
+- `room.created`
+- `chat.message`
+
+## i18n
+- `l(key, fallback)` – looks up `key` in `en.json` and returns `fallback` when missing.
+
+## Redis Keys
+- `USERS_SET`
+- `ROOMS_SET`
+- `userKey(id)`
+- `roomKey(id)`
+- `roomMessagesKey(id)`

--- a/packages/shared/src/en.json
+++ b/packages/shared/src/en.json
@@ -1,0 +1,4 @@
+{
+  "welcome": "Welcome",
+  "goodbye": "Goodbye"
+}

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,0 +1,3 @@
+export const LOBBY_JOINED = 'lobby.joined';
+export const ROOM_CREATED = 'room.created';
+export const CHAT_MESSAGE = 'chat.message';

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -1,0 +1,7 @@
+import en from './en.json' assert { type: 'json' };
+
+const dictionary: Record<string, string> = en;
+
+export function l(key: string, fallback = ''): string {
+  return dictionary[key] ?? fallback;
+}

--- a/packages/shared/src/redisKeys.ts
+++ b/packages/shared/src/redisKeys.ts
@@ -1,0 +1,6 @@
+export const USERS_SET = 'users';
+export const ROOMS_SET = 'rooms';
+
+export const userKey = (id: string) => `user:${id}`;
+export const roomKey = (id: string) => `room:${id}`;
+export const roomMessagesKey = (id: string) => `room:${id}:messages`;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,23 @@
+export interface User {
+  id: string;
+  name: string;
+}
+
+export interface RoomMeta {
+  id: string;
+  name: string;
+  users: User[];
+}
+
+export interface Message {
+  id: string;
+  roomId: string;
+  userId: string;
+  content: string;
+  timestamp: number;
+}
+
+export interface LobbySnapshot {
+  users: User[];
+  rooms: RoomMeta[];
+}


### PR DESCRIPTION
## Summary
- add shared type interfaces for users, rooms, messages and lobby snapshots
- define common event string constants
- add i18n lookup helper with English dictionary
- expose Redis key generators and constants
- document shared exports in package README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee3bf3a1c8328969b12685ce4cb99