### PR TITLE
feat: add google oauth session handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=your-google-redirect-uri
 REDIS_URL=redis://localhost:6379
 REDIS_PASSWORD=your-redis-password
 SESSION_SECRET=your-session-secret

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,6 +1,6 @@
 # Серверное приложение
 
-Простой сервер Express с подключением к Redis.
+Сервер Express с авторизацией через Google OAuth и хранением состояния в Redis.
 
 ## Скрипты
 
@@ -20,4 +20,11 @@ cp .env.example .env
 
 Задайте `PORT` и `REDIS_URL` в соответствии с вашим окружением.
 
+Для OAuth необходимы переменные `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` и `GOOGLE_REDIRECT_URI`.
+
 Эндпоинт `GET /health` проверяет подключение к Redis и возвращает `{ "status": "ok" }` при успехе.
+
+## Аутентификация
+
+- `POST /auth/google` — принимает `id_token`, проверяет его через Google API, создаёт сессию и устанавливает httpOnly cookie.
+- `GET /me` — возвращает текущего пользователя по валидной cookie.

--- a/apps/server/src/errorHandler.ts
+++ b/apps/server/src/errorHandler.ts
@@ -1,6 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 
-export function errorHandler(err: Error, _req: Request, res: Response, _next: NextFunction) {
+export function errorHandler(err: any, req: Request, res: Response, _next: NextFunction) {
   console.error(err);
-  res.status(500).json({ message: 'Internal Server Error' });
+  const status = err.status || 500;
+  const code = err.code || 'INTERNAL_ERROR';
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ error: { code, message }, requestId: req.requestId });
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,8 +2,10 @@ import express, { Request, Response, NextFunction } from 'express';
 import { config } from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { randomUUID } from 'crypto';
 import redis from './redis.js';
 import { errorHandler } from './errorHandler.js';
+import { requireSession } from './session.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,6 +15,12 @@ config({ path: path.resolve(__dirname, '../../../.env') });
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+app.use(express.json());
+app.use((req, _res, next) => {
+  req.requestId = randomUUID();
+  next();
+});
+
 app.get('/health', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     await redis.ping();
@@ -20,6 +28,49 @@ app.get('/health', async (_req: Request, res: Response, next: NextFunction) => {
   } catch (err) {
     next(err);
   }
+});
+
+app.post('/auth/google', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id_token: idToken } = req.body || {};
+    if (!idToken) {
+      return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'id_token required' }, requestId: req.requestId });
+    }
+    const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${idToken}`);
+    if (!response.ok) {
+      return res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Unable to verify token' }, requestId: req.requestId });
+    }
+    const tokenInfo = await response.json();
+    if (tokenInfo.aud !== process.env.GOOGLE_CLIENT_ID) {
+      return res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid audience' }, requestId: req.requestId });
+    }
+    const email = tokenInfo.email as string;
+    const name = (tokenInfo.name as string) || 'Noname';
+    const sessionId = randomUUID();
+
+    const existingSession = await redis.get(`user:${email}:session`);
+    if (existingSession) {
+      await redis.del(`session:${existingSession}`);
+      await redis.lrem('lobby:queue', 0, email);
+      const roomKeys = await redis.keys('room:*:users');
+      for (const key of roomKeys) {
+        await redis.srem(key, email);
+        await redis.lrem(key, 0, email);
+      }
+    }
+
+    await redis.set(`user:${email}:session`, sessionId);
+    await redis.set(`session:${sessionId}`, JSON.stringify({ uid: email, name }));
+
+    res.cookie('sessionId', sessionId, { httpOnly: true, sameSite: 'lax' });
+    res.json({ user: { uid: email, name } });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/me', requireSession, (req: Request, res: Response) => {
+  res.json({ user: req.user });
 });
 
 app.use(errorHandler);

--- a/apps/server/src/session.ts
+++ b/apps/server/src/session.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import redis from './redis.js';
+
+function parseCookies(req: Request): Record<string, string> {
+  const header = req.headers.cookie;
+  const cookies: Record<string, string> = {};
+  if (!header) return cookies;
+  for (const part of header.split(';')) {
+    const [key, ...v] = part.trim().split('=');
+    cookies[key] = decodeURIComponent(v.join('='));
+  }
+  return cookies;
+}
+
+export async function requireSession(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cookies = parseCookies(req);
+    const sessionId = cookies['sessionId'];
+    if (!sessionId) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Missing session' }, requestId: req.requestId });
+    }
+    const sessionData = await redis.get(`session:${sessionId}`);
+    if (!sessionData) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid session' }, requestId: req.requestId });
+    }
+    const user = JSON.parse(sessionData) as { uid: string; name: string };
+    const currentSession = await redis.get(`user:${user.uid}:session`);
+    if (currentSession !== sessionId) {
+      return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Session expired' }, requestId: req.requestId });
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/server/src/types.d.ts
+++ b/apps/server/src/types.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+      user?: { uid: string; name: string };
+    }
+  }
+}
+
+export {};

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,11 +2,11 @@
 Выполненные пункты отмечаются префиксом [DONE], пропущенные — [SKIP].
 
 - [DONE] Документация: технический план (README) и спецификация API
-- [ ] Структура монорепозитория: apps/, packages/, infra/ и .env.example
+- [DONE] Структура монорепозитория: apps/, packages/, infra/ и .env.example
 - [SKIP] Docker Compose инфраструктура и Makefile
 - [DONE] Общие сущности и схема ключей Redis в packages/shared
 - [DONE] Каркас сервера на Node.js + Express, Redis и /health
-- [ ] Авторизация через Google OAuth и управление сессиями
+- [DONE] Авторизация через Google OAuth и управление сессиями
 - [ ] WebSocket API
 - [ ] Лобби и комнаты: очередь, автоматическое/ручное создание, хранение в Redis
 - [ ] Чат: отправка сообщений, mini/full UI


### PR DESCRIPTION
## Summary
- implement Google OAuth login and session endpoints
- add session middleware and standardized error responses
- document auth setup and mark roadmap item as done
- mark monorepo structure item as completed

## Testing
- `npm test`
- `npm run build -w @lunawar/server`


------
https://chatgpt.com/codex/tasks/task_e_68aeecd71cb08328a9a4515154e237d6