### PR TITLE
Add logout flow and improve lobby UX

### DIFF
--- a/apps/server/src/logout.test.ts
+++ b/apps/server/src/logout.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { test } from 'vitest';
+// @ts-ignore
+import request from 'supertest';
+import { createApp } from './app.js';
+import redis from './redis.js';
+
+test('POST /auth/logout clears session', async () => {
+  const app = createApp();
+  const uid = 'user@example.com';
+  const sessionId = 'sess1';
+  await redis.set(`user:${uid}:session`, sessionId);
+  await redis.set(`session:${sessionId}`, JSON.stringify({ uid, name: 'User' }));
+  const res = await request(app)
+    .post('/auth/logout')
+    .set('Cookie', [`sessionId=${sessionId}`]);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.ok, true);
+  const sess = await redis.get(`session:${sessionId}`);
+  assert.strictEqual(sess, null);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -47,7 +47,8 @@ export default function App() {
       body: JSON.stringify({ id_token: cred })
     });
     if (res.ok) {
-      setUser(await res.json());
+      const d = await res.json();
+      setUser(d.user);
     }
   }
 
@@ -57,14 +58,29 @@ export default function App() {
 
   async function joinLobby() {
     await fetch('/lobby/join', { method: 'POST' });
+    const d = await fetch('/lobby').then(r => r.json());
+    setLobby(d.snapshot);
   }
   async function leaveLobby() {
     await fetch('/lobby/leave', { method: 'POST' });
+    const d = await fetch('/lobby').then(r => r.json());
+    setLobby(d.snapshot);
+  }
+
+  async function logout() {
+    await fetch('/auth/logout', { method: 'POST' });
+    setUser(null);
+    setLobby(null);
+    setRooms([]);
   }
 
   return (
     <div>
       <h1>{l('ui.lobby', 'Lobby')}</h1>
+      <p>
+        {l('ui.loggedInAs', 'Logged in as')}: {user.name}
+        <button onClick={logout}>{l('ui.logout', 'Logout')}</button>
+      </p>
       <button onClick={joinLobby}>{l('ui.joinLobby', 'Join Lobby')}</button>
       <button onClick={leaveLobby}>{l('ui.leaveLobby', 'Leave Lobby')}</button>
       {lobby && (

--- a/packages/shared/src/en.json
+++ b/packages/shared/src/en.json
@@ -5,5 +5,7 @@
   "ui.joinLobby": "Join Lobby",
   "ui.leaveLobby": "Leave Lobby",
   "ui.rooms": "Rooms",
-  "ui.lobbyUsers": "Lobby Users"
+  "ui.lobbyUsers": "Lobby Users",
+  "ui.loggedInAs": "Logged in as",
+  "ui.logout": "Logout"
 }


### PR DESCRIPTION
## Summary
- log each backend request/response
- add authentication logout endpoint
- show logged-in user with logout button and update lobby after join/leave
- assert authenticated user exists in server routes

## Testing
- `npm run build -w @lunawar/server`
- `npm test -w @lunawar/server` *(fails: Cannot find module 'semver/functions/gte'; Redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b735e7b40083288c9b6db50dda213b