### PR TITLE
feat: allow lobby config defaults from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ REDIS_URL=redis://localhost:6379
 REDIS_PASSWORD=your-redis-password
 SESSION_SECRET=your-session-secret
 PORT=3000
+CONFIG_ROOM_SIZE_DEFAULT=0
+CONFIG_AUTO_MATCH_DEFAULT=false

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,6 +7,7 @@ import {
   joinLobby,
   leaveLobby,
   getLobbySnapshot,
+  getConfig,
 } from './lobby.js';
 import {
   createRoom,
@@ -16,7 +17,6 @@ import {
 } from './rooms.js';
 import {
   LOBBY_QUEUE,
-  CONFIG_ROOM_SIZE,
 } from '@lunawar/shared/src/redisKeys.js';
 
 export function createApp() {
@@ -181,7 +181,7 @@ export function createApp() {
     try {
       let users: string[] = req.body?.uids;
       if (!Array.isArray(users) || users.length === 0) {
-        const roomSize = parseInt((await redis.get(CONFIG_ROOM_SIZE)) || '0');
+        const { roomSize } = await getConfig();
         users = await redis.lrange(LOBBY_QUEUE, 0, roomSize - 1);
         if (users.length) {
           await redis.ltrim(LOBBY_QUEUE, users.length, -1);

--- a/apps/server/src/lobby.rooms.test.ts
+++ b/apps/server/src/lobby.rooms.test.ts
@@ -46,6 +46,19 @@ test('auto room creation from lobby', async () => {
   assert.deepStrictEqual(q, []);
 });
 
+test('env defaults used for lobby config', async () => {
+  await redis.flushall();
+  mockPublish();
+  process.env.CONFIG_AUTO_MATCH_DEFAULT = 'true';
+  process.env.CONFIG_ROOM_SIZE_DEFAULT = '2';
+  await joinLobby('a');
+  await joinLobby('b');
+  const rooms = await getRooms();
+  assert.strictEqual(rooms.length, 1);
+  delete process.env.CONFIG_AUTO_MATCH_DEFAULT;
+  delete process.env.CONFIG_ROOM_SIZE_DEFAULT;
+});
+
 test('manual room creation', async () => {
   await redis.flushall();
   mockPublish();


### PR DESCRIPTION
## Summary
- read default lobby config from `CONFIG_ROOM_SIZE_DEFAULT` and `CONFIG_AUTO_MATCH_DEFAULT`
- expose helper to fetch lobby config and use it across server
- document new environment variables and test env defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b978e9e2148328a958125684665d8a