### PR TITLE
feat(server): add session TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ GOOGLE_REDIRECT_URI=your-google-redirect-uri
 REDIS_URL=redis://localhost:6379
 REDIS_PASSWORD=your-redis-password
 SESSION_SECRET=your-session-secret
+SESSION_TTL=604800000
 PORT=3000
 CONFIG_ROOM_SIZE_DEFAULT=0
 CONFIG_AUTO_MATCH_DEFAULT=false


### PR DESCRIPTION
## Summary
- configure session TTL via `SESSION_TTL`
- apply TTL to auth cookie and Redis session records

## Testing
- `npm test` *(fails: Cannot find module 'semver/functions/gte'; Redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b97ec9fd948328ad26c36f634ee2f5