### PR TITLE
feat(web): fetch session on mount

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,17 @@ export default function App() {
   const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
+    fetch('/me').then(async (r) => {
+      if (r.status === 200) {
+        const d = await r.json();
+        setUser(d.user);
+      } else if (r.status === 401) {
+        // user remains null
+      }
+    });
+  }, []);
+
+  useEffect(() => {
     if (!user) return;
     fetch('/lobby').then(r => r.json()).then((d) => setLobby(d.snapshot));
     fetch('/rooms').then(r => r.json()).then((d) => setRooms(d.rooms));


### PR DESCRIPTION
## Summary
- fetch /me on app load to restore session

## Testing
- `npm test` *(fails: Cannot find module 'semver/functions/gte'; Redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9842730448328bd7a3a52afb3df7c