### PR TITLE
fix proxy for session check

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       '/auth': 'http://localhost:3000',
       '/lobby': 'http://localhost:3000',
       '/rooms': 'http://localhost:3000',
+      '/me': 'http://localhost:3000',
       '/ws': {
         target: 'ws://localhost:3000',
         ws: true


### PR DESCRIPTION
## Summary
- proxy `/me` to backend so the frontend can restore sessions after refresh

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68b97bcf61a4832891f92e965029582b