### PR TITLE
fix: import lobby queue key

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import redis from './redis.js';
+import { LOBBY_QUEUE } from '@lunawar/shared/src/redisKeys.js';
 import { errorHandler } from './errorHandler.js';
 import { requireSession } from './session.js';
 import {


### PR DESCRIPTION
## Summary
- import lobby queue key constant into server app to build admin room creation

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'semver/functions/gte'; Redis connection ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b98bd236b0832882851ae7dedbed7d