### PR TITLE
test: mock publish returns event

### DIFF
--- a/apps/server/src/lobby.rooms.test.ts
+++ b/apps/server/src/lobby.rooms.test.ts
@@ -15,7 +15,7 @@ function mockPublish() {
   const events: any[] = [];
   vi.spyOn(ws, 'publish').mockImplementation(async (_ch: string, _type: string, payload: any) => {
     events.push(payload);
-    return undefined;
+    return { eventId: 0, epoch: 0, ts: Date.now(), type: _type, payload };
   });
   return events;
 }


### PR DESCRIPTION
## Summary
- fix mocked publish in lobby rooms tests to return an event object

## Testing
- `npm run build -w @lunawar/server`
- `npm test -w @lunawar/server` *(fails: Cannot find module 'semver/functions/gte'; connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68b99d35b8448328ae982f7a9214f0d3