### PR TITLE
Improve room chat layout

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,6 +2,8 @@
 
 React client for players. Supports Google OAuth based sign-in, lobby interaction and room listing. After successful authentication it connects to the backend via WebSocket to receive real time updates.
 
+Inside a game room the client displays an empty playfield with a mini chat pinned to the side showing the last three messages. Pressing the <code>`</code> key toggles the full chat view with the entire history and input. A leave button is available in the top-left corner of the screen.
+
 ## Configuration
 
 This app uses Google Identity Services. Provide your OAuth client ID via the `GOOGLE_CLIENT_ID` environment variable when running or building the app. You can define it in the repository’s `.env` file or pass it inline:

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,0 +1,73 @@
+.room {
+  position: relative;
+  background: #000;
+  color: #fff;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.exit {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 6px 10px;
+}
+
+.chat {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  box-sizing: border-box;
+  color: #fff;
+}
+
+.chat.mini .messages {
+  max-height: 150px;
+  overflow: hidden;
+}
+
+.chat.full {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat.full .messages {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.messages li + li {
+  margin-top: 4px;
+}
+
+.input {
+  display: flex;
+  margin-top: 8px;
+}
+
+.input input {
+  flex: 1;
+}
+
+.lobby {
+  padding: 20px;
+}
+
+.lobby ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.lobby li + li {
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- show dedicated room view with mini chat, full chat toggle, and exit button
- style lobby and room with simple CSS
- document room chat behaviour in web README

## Testing
- `npm test --workspace=apps/web`
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379, Cannot find module 'semver/functions/gte')*

------
https://chatgpt.com/codex/tasks/task_e_68b99f56ce54832896eefd8577e8d6f2