### PR TITLE
chore: include admin app in dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev:docker": "bash scripts/dev-with-redis.sh",
     "dev:web": "npm run dev -w @lunawar/web",
     "dev:server": "npm run dev:docker",
-    "dev": "npm-run-all --parallel dev:web dev:server",
+    "dev:admin": "npm run dev -w @lunawar/admin",
+    "dev": "npm-run-all --parallel dev:web dev:server dev:admin",
     "build": "npm run build --workspaces",
     "setup": "npm install",
     "start": "npm run setup && npm run build && npm run dev"


### PR DESCRIPTION
## Summary
- add admin app dev script to root workspace
- run admin alongside web and server in dev mode

## Testing
- `npm test --workspaces --if-present` *(fails: Cannot find module 'semver/functions/gte'; Redis connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68ba889b102c8328b77fff6954f1d984